### PR TITLE
Fix build errors

### DIFF
--- a/decoders/drm-decoder/eqdisplay.h
+++ b/decoders/drm-decoder/eqdisplay.h
@@ -41,6 +41,7 @@
 #include	<qwt_plot_zoomer.h>
 #include	<qwt_plot_panner.h>
 #include	<qwt_plot_layout.h>
+#include	<qpen.h>
 
 class EQDisplay {
 public:

--- a/swradio-8.pro
+++ b/swradio-8.pro
@@ -3,7 +3,7 @@
 ######################################################################
 TEMPLATE = app
 QT	+= widgets xml
-CONFIG	+= console
+CONFIG	+= console qwt qwt-qt5
 #CONFIG	-= console
 TARGET	= swradio-9
 QMAKE_CXXFLAGS  += -std=c++14
@@ -181,8 +181,7 @@ CONFIG		+= acars-decoder
 #CONFIG		+= test-decoder
 LIBS		+= -L/usr/lib64
 LIBS		+= -L/lib64
-INCLUDEPATH	+= /usr/include/qt5/qwt
-LIBS		+= -lqwt-qt5 -lrt -lsndfile -lsamplerate -lportaudio -lusb-1.0 -lfftw3f -ldl
+LIBS		+= -lrt -lsndfile -lsamplerate -lportaudio -lusb-1.0 -lfftw3f -ldl
 }
 
 win32 {


### PR DESCRIPTION
I wanted to try this project but I had a few issues compiling it (first with qwt and qwt-qt5 not being found, and then errors related to `QPen`).

This PR implements fixes for those issues, allowing the project to successfully compile:

* removes hardcoded qwt and qwt-qt5 build options, and uses `CONFIG` to let the build system figure out by itself how to get it right
* adds a missing header that was leading to the mentioned compilation errors related to `QPen`

This was only tested on a Linux system (ArchLinux), but as it makes the build config more generic I believe it should work as well for the other platforms, and would likely fix #4 #9 and #11.  Although it might be needed to remove the hardcoded stuff from the Windows and MacOS sections, but I don't have a system to test these on so I didn't touch those parts.